### PR TITLE
Remain the weights of vgg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -637,3 +637,4 @@ dmypy.json
 .pytype/
 
 .Rproj.user
+!**/lpips/weights/*


### PR DESCRIPTION
We found that the vgg checkpoint is important for the experiments but the checkpoint is included in the gitignore while it only has 8kb